### PR TITLE
fix: ensure Terraform tag is included in local variables for clarity

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -10,5 +10,6 @@ locals {
     Project     = "apple_update_notification"
     Environment = var.environment
     GitHubRepo  = "github.com/cullancarey/apple_update_notification"
+    Terraform   = "true"
   }
 }


### PR DESCRIPTION
This pull request makes a small update to the Terraform configuration by adding a new local variable to indicate that Terraform is being used. This helps with environment identification and management.

- Added a `Terraform` key with value `"true"` to the `locals` block in `terraform/locals.tf` to signal Terraform usage.