### PR TITLE
Implement error notification system and format code consistency

### DIFF
--- a/lambdas/apple_send_update.py
+++ b/lambdas/apple_send_update.py
@@ -10,12 +10,14 @@ try:
         authenticate_twitter_client,
         create_dynamodb_resource,
         mark_tweet_posted,
+        notify_error,
     )
 except ImportError:
     from apple_utils import (
         authenticate_twitter_client,
         create_dynamodb_resource,
         mark_tweet_posted,
+        notify_error,
     )
 
 # -------------------------------------------------------------------------
@@ -41,6 +43,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     dynamodb_table_name = os.getenv(DYNAMODB_TABLE_ENV_VAR)
     if not dynamodb_table_name:
         logger.error("Environment variable '%s' is not set.", DYNAMODB_TABLE_ENV_VAR)
+        notify_error(
+            source="apple_send_update",
+            error_message="Missing required Lambda environment variable.",
+            details={"variable": DYNAMODB_TABLE_ENV_VAR},
+        )
         return {
             "batchItemFailures": [
                 {"itemIdentifier": r["eventID"]} for r in records if r.get("eventID")
@@ -56,6 +63,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         logger.info("Twitter client successfully authenticated.")
     except Exception as e:
         logger.error(f"Failed to authenticate Twitter client: {e}", exc_info=True)
+        notify_error(
+            source="apple_send_update",
+            error_message="Twitter authentication failed.",
+            details={"exception": str(e)},
+        )
         return {
             "batchItemFailures": [
                 {"itemIdentifier": r["eventID"]} for r in records if r.get("eventID")
@@ -93,6 +105,14 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
         except Exception as e:
             logger.error(f"Error processing record: {e}", exc_info=True)
+            notify_error(
+                source="apple_send_update",
+                error_message="Error processing DynamoDB stream record.",
+                details={
+                    "event_id": event_id,
+                    "exception": str(e),
+                },
+            )
             if event_id:
                 failures.append({"itemIdentifier": event_id})
 

--- a/lambdas/apple_utils.py
+++ b/lambdas/apple_utils.py
@@ -1,5 +1,7 @@
 """AWS SDK utilities for Parameter Store, DynamoDB, and Twitter interactions."""
 
+import json
+import os
 import logging
 import boto3
 import tweepy
@@ -18,6 +20,7 @@ logger.setLevel(logging.INFO)
 # -------------------------------------------------------------------------
 PARAMETER_PREFIX = "apple_update_notification"
 TWEET_DEDUP_PREFIX = "tweet_posted"
+ERROR_ALERT_TOPIC_ENV_VAR = "error_alert_topic_arn"
 
 # -------------------------------------------------------------------------
 # Global AWS Session / Config (improves Lambda cold-start performance)
@@ -28,6 +31,7 @@ session = boto3.session.Session()
 # Global clients reused across invocations
 ssm_client = session.client("ssm", config=boto_cfg)
 dynamodb_resource = session.resource("dynamodb", config=boto_cfg)
+sns_client = session.client("sns", config=boto_cfg)
 
 
 # -------------------------------------------------------------------------
@@ -150,6 +154,28 @@ def mark_tweet_posted(table, device: str, release_version: str) -> bool:
         raise
 
 
+def notify_error(source: str, error_message: str, details: dict | None = None) -> None:
+    """Publish an error notification to SNS when an alert topic is configured."""
+    topic_arn = os.getenv(ERROR_ALERT_TOPIC_ENV_VAR)
+    if not topic_arn:
+        return
+
+    payload = {
+        "source": source,
+        "error_message": error_message,
+        "details": details or {},
+    }
+
+    try:
+        sns_client.publish(
+            TopicArn=topic_arn,
+            Subject=f"Lambda error: {source}",
+            Message=json.dumps(payload, default=str),
+        )
+    except (ClientError, BotoCoreError):
+        logger.error("Failed to publish SNS error notification.", exc_info=True)
+
+
 # -------------------------------------------------------------------------
 # Twitter Client Authentication
 # -------------------------------------------------------------------------
@@ -193,6 +219,7 @@ __all__ = [
     "create_dynamodb_resource",
     "get_device_item",
     "mark_tweet_posted",
+    "notify_error",
     "authenticate_twitter_client",
     "ParameterRetrievalError",
     "DynamoDBItemNotFound",

--- a/lambdas/apple_web_scrape.py
+++ b/lambdas/apple_web_scrape.py
@@ -7,9 +7,9 @@ from bs4 import BeautifulSoup
 from botocore.exceptions import ClientError
 
 try:
-    from .apple_utils import get_device_item, create_dynamodb_resource
+    from .apple_utils import get_device_item, create_dynamodb_resource, notify_error
 except ImportError:
-    from apple_utils import get_device_item, create_dynamodb_resource
+    from apple_utils import get_device_item, create_dynamodb_resource, notify_error
 
 # Constants
 APPLE_RELEASE_URL = "https://support.apple.com/en-us/100100"
@@ -28,13 +28,28 @@ def fetch_apple_release_page(url=APPLE_RELEASE_URL):
         response = http.request("GET", url, redirect=True)
         if response.status != 200:
             logger.error(f"Failed to fetch URL {url}. Status code: {response.status}")
+            notify_error(
+                source="apple_web_scrape",
+                error_message="Failed to fetch Apple release page.",
+                details={"status_code": response.status, "url": url},
+            )
             return None
         return response.data.decode("utf-8", errors="ignore")
     except urllib3.exceptions.HTTPError as e:
         logger.error(f"HTTP error occurred while fetching Apple release page: {e}")
+        notify_error(
+            source="apple_web_scrape",
+            error_message="HTTP error while fetching Apple release page.",
+            details={"exception": str(e), "url": url},
+        )
         return None
     except Exception as e:
         logger.error(f"Error fetching Apple release page: {e}", exc_info=True)
+        notify_error(
+            source="apple_web_scrape",
+            error_message="Unexpected error while fetching Apple release page.",
+            details={"exception": str(e), "url": url},
+        )
         return None
 
 
@@ -140,6 +155,15 @@ def update_dynamodb(table, device, release_version, release_statement):
         logger.error(
             f"Error updating {device} for version {release_version} in DynamoDB: {err}"
         )
+        notify_error(
+            source="apple_web_scrape",
+            error_message="Failed to update DynamoDB release state.",
+            details={
+                "device": device,
+                "release_version": release_version,
+                "exception": str(err),
+            },
+        )
         return False
     else:
         logger.info(
@@ -153,11 +177,20 @@ def lambda_handler(event, context):
     dynamodb_table_name = os.getenv(DYNAMODB_TABLE_ENV_VAR)
     if not dynamodb_table_name:
         logger.error(f"Environment variable '{DYNAMODB_TABLE_ENV_VAR}' is not set.")
+        notify_error(
+            source="apple_web_scrape",
+            error_message="Missing required Lambda environment variable.",
+            details={"variable": DYNAMODB_TABLE_ENV_VAR},
+        )
         return
 
     latest_releases = get_latest_releases()
     if not latest_releases:
         logger.error("Failed to retrieve latest releases.")
+        notify_error(
+            source="apple_web_scrape",
+            error_message="Failed to retrieve latest Apple releases.",
+        )
         return
 
     logger.info(f"Latest releases fetched: {latest_releases}")

--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -1,0 +1,13 @@
+resource "aws_sns_topic" "lambda_error_alerts" {
+  count = var.error_alert_email != null && trimspace(var.error_alert_email) != "" ? 1 : 0
+
+  name = "apple-update-notification-lambda-errors-${var.environment}"
+}
+
+resource "aws_sns_topic_subscription" "lambda_error_alert_email" {
+  count = var.error_alert_email != null && trimspace(var.error_alert_email) != "" ? 1 : 0
+
+  topic_arn = aws_sns_topic.lambda_error_alerts[0].arn
+  protocol  = "email"
+  endpoint  = trimspace(var.error_alert_email)
+}

--- a/terraform/develop.tfvars
+++ b/terraform/develop.tfvars
@@ -1,5 +1,5 @@
 # root_domain_name = "develop.appleupdatenotification.com"
 environment = "development"
 # subscription_intake_api_domain = "subscription.develop.appleupdatenotification.com"
-twitter_username = "UpdateAppletest"
+twitter_username  = "UpdateAppletest"
 error_alert_email = "cullancarey@gmail.com"

--- a/terraform/develop.tfvars
+++ b/terraform/develop.tfvars
@@ -2,3 +2,4 @@
 environment = "development"
 # subscription_intake_api_domain = "subscription.develop.appleupdatenotification.com"
 twitter_username = "UpdateAppletest"
+error_alert_email = "cullancarey@gmail.com"

--- a/terraform/main.tfvars
+++ b/terraform/main.tfvars
@@ -2,3 +2,4 @@
 environment = "production"
 # subscription_intake_api_domain = "subscription.appleupdatenotification.com"
 twitter_username = "UpdateApple_"
+error_alert_email = "cullancarey@gmail.com"

--- a/terraform/main.tfvars
+++ b/terraform/main.tfvars
@@ -1,5 +1,5 @@
 # root_domain_name = "appleupdatenotification.com"
 environment = "production"
 # subscription_intake_api_domain = "subscription.appleupdatenotification.com"
-twitter_username = "UpdateApple_"
+twitter_username  = "UpdateApple_"
 error_alert_email = "cullancarey@gmail.com"

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -21,11 +21,13 @@ module "lambda_service" {
   dynamodb_table_name       = module.data_store.table_name
   dynamodb_table_arn        = module.data_store.table_arn
   dynamodb_table_stream_arn = module.data_store.table_stream_arn
+  error_alert_topic_arn     = try(aws_sns_topic.lambda_error_alerts[0].arn, null)
 }
 
 module "observability" {
   source = "./modules/observability"
 
-  environment      = var.environment
-  lambda_functions = module.lambda_service.lambda_functions
+  environment           = var.environment
+  lambda_functions      = module.lambda_service.lambda_functions
+  error_alert_topic_arn = try(aws_sns_topic.lambda_error_alerts[0].arn, null)
 }

--- a/terraform/modules/lambda-service/main.tf
+++ b/terraform/modules/lambda-service/main.tf
@@ -168,8 +168,8 @@ resource "aws_lambda_function" "lambda_functions" {
   environment {
     variables = merge(
       {
-        environment         = var.environment
-        dynamodb_table_name = var.dynamodb_table_name
+        environment           = var.environment
+        dynamodb_table_name   = var.dynamodb_table_name
         error_alert_topic_arn = var.error_alert_topic_arn
       },
       each.key == "apple_web_scrape" ? {

--- a/terraform/modules/lambda-service/main.tf
+++ b/terraform/modules/lambda-service/main.tf
@@ -30,6 +30,11 @@ variable "dynamodb_table_stream_arn" {
   type = string
 }
 
+variable "error_alert_topic_arn" {
+  type    = string
+  default = null
+}
+
 locals {
   name_prefix = "apple-${var.environment}"
 
@@ -121,6 +126,17 @@ data "aws_iam_policy_document" "lambda_policies" {
       effect = "Allow"
     }
   }
+
+  dynamic "statement" {
+    for_each = var.error_alert_topic_arn != null && trimspace(var.error_alert_topic_arn) != "" ? [1] : []
+
+    content {
+      sid       = "SnsPublishAlerts"
+      actions   = ["sns:Publish"]
+      resources = [var.error_alert_topic_arn]
+      effect    = "Allow"
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "lambda_policies" {
@@ -154,6 +170,7 @@ resource "aws_lambda_function" "lambda_functions" {
       {
         environment         = var.environment
         dynamodb_table_name = var.dynamodb_table_name
+        error_alert_topic_arn = var.error_alert_topic_arn
       },
       each.key == "apple_web_scrape" ? {
         dynamodb_table_name = var.dynamodb_table_name

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -10,11 +10,19 @@ variable "lambda_functions" {
   }))
 }
 
+variable "error_alert_topic_arn" {
+  type        = string
+  default     = null
+  description = "Optional SNS topic ARN for Lambda error notifications."
+}
+
 locals {
   scheduled_lambdas = {
     for key, fn in var.lambda_functions : key => fn
     if try(fn.schedule, null) != null
   }
+
+  lambda_error_alarm_actions = var.error_alert_topic_arn != null && trimspace(var.error_alert_topic_arn) != "" ? [var.error_alert_topic_arn] : []
 }
 
 resource "aws_cloudwatch_log_group" "lambda_logs" {
@@ -22,6 +30,29 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
 
   name              = "/aws/lambda/${each.value.name}"
   retention_in_days = var.environment == "production" ? 365 : 180
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  for_each = var.lambda_functions
+
+  alarm_name          = "${each.value.name}-errors-${var.environment}"
+  alarm_description   = "Triggers when ${each.value.name} reports Lambda errors."
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = each.value.name
+  }
+
+  alarm_actions             = local.lambda_error_alarm_actions
+  ok_actions                = local.lambda_error_alarm_actions
+  insufficient_data_actions = []
 }
 
 resource "aws_cloudwatch_event_rule" "lambda_schedules" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,3 +18,9 @@ variable "aws_region" {
   description = "AWS region where infrastructure is deployed."
   default     = "us-east-2"
 }
+
+variable "error_alert_email" {
+  type        = string
+  description = "Optional email address for SNS notifications when Lambda errors occur."
+  default     = null
+}

--- a/tests/test_apple_send_update_lambda.py
+++ b/tests/test_apple_send_update_lambda.py
@@ -83,13 +83,20 @@ def test_lambda_handler_success(
     side_effect=Exception("Auth failed"),
 )
 @patch("lambdas.apple_send_update.create_dynamodb_resource")
-def test_lambda_handler_auth_failure(mock_dynamodb_resource, mock_auth, dynamodb_event):
+@patch("lambdas.apple_send_update.notify_error")
+def test_lambda_handler_auth_failure(
+    mock_notify,
+    mock_dynamodb_resource,
+    mock_auth,
+    dynamodb_event,
+):
     """If authentication fails, lambda should log and exit without tweeting."""
     mock_dynamodb_resource.return_value = MagicMock()
     with patch.dict("os.environ", {"dynamodb_table_name": "table"}):
         result = aws.lambda_handler(dynamodb_event, {})
     mock_auth.assert_called_once()
     assert len(result["batchItemFailures"]) == 2
+    mock_notify.assert_called_once()
 
 
 @patch("lambdas.apple_send_update.authenticate_twitter_client")

--- a/tests/test_apple_utils.py
+++ b/tests/test_apple_utils.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from lambdas.apple_utils import notify_error
+
+
+@patch("lambdas.apple_utils.sns_client.publish")
+def test_notify_error_publishes_when_topic_configured(mock_publish):
+    with patch.dict("os.environ", {"error_alert_topic_arn": "arn:aws:sns:us-east-2:123456789012:alerts"}):
+        notify_error(
+            source="apple_send_update",
+            error_message="test error",
+            details={"event_id": "evt-1"},
+        )
+
+    mock_publish.assert_called_once()
+    publish_kwargs = mock_publish.call_args.kwargs
+    assert publish_kwargs["TopicArn"] == "arn:aws:sns:us-east-2:123456789012:alerts"
+    assert "apple_send_update" in publish_kwargs["Subject"]
+    assert "test error" in publish_kwargs["Message"]
+
+
+@patch("lambdas.apple_utils.sns_client.publish")
+def test_notify_error_noop_without_topic(mock_publish):
+    with patch.dict("os.environ", {}, clear=True):
+        notify_error(source="apple_web_scrape", error_message="test error")
+
+    mock_publish.assert_not_called()

--- a/tests/test_apple_utils.py
+++ b/tests/test_apple_utils.py
@@ -5,7 +5,10 @@ from lambdas.apple_utils import notify_error
 
 @patch("lambdas.apple_utils.sns_client.publish")
 def test_notify_error_publishes_when_topic_configured(mock_publish):
-    with patch.dict("os.environ", {"error_alert_topic_arn": "arn:aws:sns:us-east-2:123456789012:alerts"}):
+    with patch.dict(
+        "os.environ",
+        {"error_alert_topic_arn": "arn:aws:sns:us-east-2:123456789012:alerts"},
+    ):
         notify_error(
             source="apple_send_update",
             error_message="test error",

--- a/tests/test_apple_web_scrape_lambda.py
+++ b/tests/test_apple_web_scrape_lambda.py
@@ -57,13 +57,15 @@ def test_fetch_apple_release_page_success(mock_pool):
 
 
 @patch("lambdas.apple_web_scrape.urllib3.PoolManager")
-def test_fetch_apple_release_page_failure(mock_pool):
+@patch("lambdas.apple_web_scrape.notify_error")
+def test_fetch_apple_release_page_failure(mock_notify, mock_pool):
     mock_http = MagicMock()
     mock_pool.return_value = mock_http
     mock_http.request.return_value.status = 404
 
     result = aws.fetch_apple_release_page("https://mock.url")
     assert result is None
+    mock_notify.assert_called_once()
 
 
 # -------------------------------------------------------------------------
@@ -243,7 +245,9 @@ def test_lambda_handler_success(
 
 
 @patch("lambdas.apple_web_scrape.create_dynamodb_resource")
-def test_lambda_handler_missing_env(mock_dynamo, monkeypatch):
+@patch("lambdas.apple_web_scrape.notify_error")
+def test_lambda_handler_missing_env(mock_notify, mock_dynamo, monkeypatch):
     monkeypatch.delenv("dynamodb_table_name", raising=False)
     aws.lambda_handler({}, {})
     mock_dynamo.assert_not_called()
+    mock_notify.assert_called_once()


### PR DESCRIPTION
This pull request introduces a robust error notification system for Lambda functions by integrating SNS-based alerts and corresponding infrastructure. Now, when a Lambda error occurs, the system will notify a configured email address, improving operational visibility and response time. The changes span both application code (Python) and Terraform infrastructure, and include comprehensive tests.

**Error Notification System**

* Added a `notify_error` utility function to `apple_utils.py` that publishes error details to an SNS topic if configured. This function is now invoked throughout the Lambda handlers (`apple_send_update.py` and `apple_web_scrape.py`) at critical failure points, such as missing environment variables, authentication failures, and external service errors. [[1]](diffhunk://#diff-454be032402e860cb47c42eb699082e2ad6f39e19cca9182a862db282446a1abR157-R178) [[2]](diffhunk://#diff-f5c9f88baaa4e6598e7756b03844138de81f3358ec8ac02b545b71071206a3a0R46-R50) [[3]](diffhunk://#diff-f5c9f88baaa4e6598e7756b03844138de81f3358ec8ac02b545b71071206a3a0R66-R70) [[4]](diffhunk://#diff-f5c9f88baaa4e6598e7756b03844138de81f3358ec8ac02b545b71071206a3a0R108-R115) [[5]](diffhunk://#diff-2f14ad6a145b5252acd14dc7ad5d68d4730080fe46eb3315257ff4296d83c98cR31-R52) [[6]](diffhunk://#diff-2f14ad6a145b5252acd14dc7ad5d68d4730080fe46eb3315257ff4296d83c98cR158-R166) [[7]](diffhunk://#diff-2f14ad6a145b5252acd14dc7ad5d68d4730080fe46eb3315257ff4296d83c98cR180-R193)

* Both Lambda handlers now import and use `notify_error` for error reporting, ensuring consistent alerting across services. [[1]](diffhunk://#diff-f5c9f88baaa4e6598e7756b03844138de81f3358ec8ac02b545b71071206a3a0R13-R20) [[2]](diffhunk://#diff-2f14ad6a145b5252acd14dc7ad5d68d4730080fe46eb3315257ff4296d83c98cL10-R12)

**Infrastructure as Code (Terraform)**

* Introduced a new SNS topic and email subscription for error alerts, parameterized by environment and email address. The Lambda IAM policies are updated to allow publishing to this topic, and the topic ARN is injected into Lambda environment variables. [[1]](diffhunk://#diff-c997c2fc2e1195328ae9ba54e007fdeb9ec405314d5cbc730860943ca511cd7bR1-R13) [[2]](diffhunk://#diff-014b44ae51dce1fb222702773baf9b1d03cb199e668c8c13f2f0df91a5a14189R24-R32) [[3]](diffhunk://#diff-ecf75e6159f1f9c8ccebeaefa31552ee72edabd44d73ebee0cdb58805c1bdf9fR33-R37) [[4]](diffhunk://#diff-ecf75e6159f1f9c8ccebeaefa31552ee72edabd44d73ebee0cdb58805c1bdf9fR129-R139) [[5]](diffhunk://#diff-ecf75e6159f1f9c8ccebeaefa31552ee72edabd44d73ebee0cdb58805c1bdf9fR173)

* Added a CloudWatch alarm for each Lambda function to trigger SNS notifications on errors, further enhancing monitoring. [[1]](diffhunk://#diff-74478f0a51cd321f7374d97f2b8928a8590e988532dc6f98671fdf68347b8ed3R13-R25) [[2]](diffhunk://#diff-74478f0a51cd321f7374d97f2b8928a8590e988532dc6f98671fdf68347b8ed3R35-R57)

* The alert email address is now configurable via Terraform variables and is set for both development and production. [[1]](diffhunk://#diff-06b58f611c26dd91b2b76506262bd16b3342f4f967af2022c5f825b9126c49a2R5) [[2]](diffhunk://#diff-567ae5aba5f30230bec9c96e67520354f76185341acde95b1a3a887611359b00R5) [[3]](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R21-R26)

**Testing**

* Added and updated unit tests to verify that `notify_error` is called when expected, and that it publishes to SNS only when configured. This ensures the reliability of the alerting mechanism. [[1]](diffhunk://#diff-fa7d5ecd1162dd30b87716ed7e9faea1d787524950ae76a870f8ea8921e08e87R1-R30) [[2]](diffhunk://#diff-69606ecebe1b34f17c9ec6475c670ffd069410aaed0b9b8b34ca56d8fd0f24c6L86-R99) [[3]](diffhunk://#diff-db151a2a365c5af16db490e2f7106ab3f376453aa7f647118c2ea04bc5f65637L60-R68) [[4]](diffhunk://#diff-db151a2a365c5af16db490e2f7106ab3f376453aa7f647118c2ea04bc5f65637L246-R253)